### PR TITLE
Fix a few things in AutoCheck refactor (rapid7#13787)

### DIFF
--- a/lib/msf/core/exploit/auto_check.rb
+++ b/lib/msf/core/exploit/auto_check.rb
@@ -1,8 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit'
-require 'msf/core/module/failure'
-
 module Msf
 module Exploit::Remote::AutoCheck
 
@@ -17,35 +14,44 @@ module Exploit::Remote::AutoCheck
 
   def exploit
     unless datastore['AutoCheck']
-      print_warning('AutoCheck is disabled. Proceeding with exploitation.')
+      print_warning('AutoCheck is disabled, proceeding with exploitation')
       return super
     end
 
     print_status('Executing automatic check (disable AutoCheck to override)')
 
-    # This isn't even my final form!
+    warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
+    error_msg = 'Enable ForceExploit to override.'
+
     case (checkcode = check)
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
       print_good(checkcode.message)
-      return super
+      super
     when Exploit::CheckCode::Detected
       print_warning(checkcode.message)
-      return super
+      super
     when Exploit::CheckCode::Safe
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
       fail_with(Module::Failure::NotVulnerable,
-                "#{checkcode.message} Disable ForceExploit to override.")
+                "#{checkcode.message} #{error_msg}")
     when Exploit::CheckCode::Unsupported
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
-      fail_with(Module::Failure::BadConfig,
-                "#{checkcode.message} Disable ForceExploit to override.")
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
+      fail_with(Module::Failure::BadConfig, "#{checkcode.message} #{error_msg}")
     else
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
-      fail_with(Module::Failure::Unknown,
-                "#{checkcode.message} Disable ForceExploit to override.")
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
+      fail_with(Module::Failure::Unknown, "#{checkcode.message} #{error_msg}")
     end
   end
 

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -91,7 +91,9 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           true,
           'Leak API key from this file (absolute path)',
-          '/opt/infra/idaccessmgr/logfile.txt'
+          '/opt/infra/idaccessmgr/logfile.txt',
+          nil, # enums
+          %r{^/.+$} # LEAK_FILE must be an absolute path
         ]
       )
     ])
@@ -118,10 +120,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['LEAK_FILE'].start_with?('/')
-      fail_with(Failure::BadConfig, 'LEAK_FILE is not an absolute path')
-    end
-
     # Randomly named file is never written to the exports directory
     create_exports_dir(
       '/opt/infra/web_cloudmgr/apache-tomcat/webapps/app/cloudmgr/exports',

--- a/spec/lib/msf/core/exploit/remote/auto_check.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check.rb
@@ -119,15 +119,15 @@ RSpec.describe Msf::Exploit::Remote::AutoCheck do
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Safe,
-                      expected_error: "The target is not exploitable. Disable ForceExploit to override."
+                      expected_error: "The target is not exploitable. Enable ForceExploit to override."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unsupported,
-                      expected_error: "This module does not support check. Disable ForceExploit to override."
+                      expected_error: "This module does not support check. Enable ForceExploit to override."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unknown,
-                      expected_error: "Cannot reliably check exploitability. Disable ForceExploit to override."
+                      expected_error: "Cannot reliably check exploitability. Enable ForceExploit to override."
     end
   end
 end


### PR DESCRIPTION
Regex-based option validation will not tell the user what they did wrong, so they'll have to read.

```
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > set leak_file alan
[-] The following options failed to validate: Value 'alan' is not valid for option 'LEAK_FILE'.
leak_file => /opt/infra/idaccessmgr/logfile.txt
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) >
```

And some updated output in the mixin:

```
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[-] The connection was refused by the remote host (127.0.0.1:443).
[!] Cannot reliably check exploitability. Target did not respond to check request.
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Target did not respond to check request. Disable ForceExploit to override.
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) >
```

```
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > run

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[-] The connection was refused by the remote host (127.0.0.1:443).
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Target did not respond to check request. Enable ForceExploit to override.
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) >
```

https://github.com/rapid7/metasploit-framework/pull/13787#discussion_r447805670